### PR TITLE
feat: add input box titles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -105,14 +105,18 @@ function App() {
           Payment Validator
         </h1>
         <div className="form-container">
+          <label htmlFor="lightning-invoice" className="input-label">Lightning Invoice</label>
           <textarea
+            id="lightning-invoice"
             placeholder="Enter Lightning Invoice"
             value={invoice}
             onChange={(e) => setInvoice(e.target.value.replace(/[\s\n]+/g, ''))}
             onKeyDown={handleKeyPress}
             className="input-field"
           />
+          <label htmlFor="lightning-preimage" className="input-label">Lightning Invoice Preimage</label>
           <input
+            id="lightning-preimage"
             type="text"
             placeholder="Enter Lightning Invoice Preimage"
             value={preimage}


### PR DESCRIPTION
I use validate-payment almost exclusively with pre-filled invoice and preimage via url params, then to some it is not clear what the data in the input boxes is. So I added a title each.

Before:
<img width="656" height="426" alt="image" src="https://github.com/user-attachments/assets/25d806d6-1937-4fae-b6ec-b7c76252613d" />

With this PR:
<img width="656" height="479" alt="image" src="https://github.com/user-attachments/assets/11afa17e-e63e-4628-ac4a-7becc5cd2fc1" />
